### PR TITLE
Postのエンドポイントとスタイルを追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/components/ui/pager/index.tsx
+++ b/src/components/ui/pager/index.tsx
@@ -2,6 +2,11 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faAngleLeft, faAngleRight } from "@fortawesome/free-solid-svg-icons"
 import styles from "./styles.module.css"
 
+/* Pager usage
+ * import Pager from "@/components/ui/pager";
+ *
+ * <Pager path="/posts/list" query={"?page=1"} totalCount={100} perPage={10} />
+ */
 type Props = {
   path: string
   query: string

--- a/src/pages/posts/[uid].tsx
+++ b/src/pages/posts/[uid].tsx
@@ -1,0 +1,90 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEdit } from "@fortawesome/free-solid-svg-icons";
+import { useState, useRef } from "react";
+
+import Layout from "@/components/layout";
+import styles from "@/styles/posts/uid.module.css";
+
+export default function PostDetail() {
+  const router = useRouter();
+  const [titleEditing, setTitleEditing] = useState(false);
+  const [bodyEditing, setBodyEditing] = useState(false);
+  const inputTitle = useRef<HTMLInputElement>(null);
+  const divTitle = useRef<HTMLDivElement>(null);
+  const textareaBody = useRef<HTMLTextAreaElement>(null);
+  const divBody = useRef<HTMLDivElement>(null);
+  const { uid } = router.query;
+  const post = {
+    id: "f7c6436a-f346-4066-bee9-57ff9566ef51",
+    title: "This is a post title",
+    body: "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis.",
+    created_at: "2023-03-26T10:04:39.445113",
+    updated_at: "2023-03-26T10:04:39.445113"
+  };
+
+  return (
+    <Layout>
+      <Head>
+        <title>{post.title}</title>
+      </Head>
+      <div className={styles.title}>
+        {!titleEditing && <h1 className={styles.headline} ref={divTitle}>{post.title}</h1>}
+        {titleEditing && <form action={`/api/posts/${uid}`} method="post">
+          <input type="text" name="title" ref={inputTitle} />
+        </form>
+        }
+        <button className={styles.editbtn} onClick={handleTitleEdit}>
+          <FontAwesomeIcon icon={faEdit} />
+          Edit
+        </button>
+      </div>
+      <div className={styles.article_wrap}>
+        <div className={styles.article}>
+          <div className={styles.article_control}>
+            <div className={styles.article_time}>Posted 2 days ago</div>
+            <div className={styles.article_edit}>
+              <button className={styles.editbtn} onClick={handleBodyEdit}>
+                <FontAwesomeIcon icon={faEdit} />
+                Edit
+              </button>
+            </div>
+          </div>
+          {!bodyEditing && <div className={styles.article_body} ref={divBody}>
+            {post.body}
+          </div>
+          }
+          {bodyEditing && <form action={`/api/posts/${uid}`} method="post">
+            <textarea name="body" ref={textareaBody} />
+          </form>
+          }
+        </div>
+      </div>
+    </Layout>
+  );
+
+  async function handleTitleEdit() {
+    setTitleEditing(!titleEditing);
+    if (!titleEditing) {
+      let titleText = divTitle.current!.innerText;
+      await sleep(10);
+      inputTitle.current!.value = titleText;
+      inputTitle.current!.focus();
+    }
+  }
+
+  async function handleBodyEdit() {
+    setBodyEditing(!bodyEditing);
+    if (!bodyEditing) {
+      let bodyText = divBody.current!.innerText;
+      await sleep(10);
+      textareaBody.current!.value = bodyText;
+      textareaBody.current!.focus();
+    }
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/pages/posts/create.tsx
+++ b/src/pages/posts/create.tsx
@@ -1,0 +1,25 @@
+import Layout from "@/components/layout";
+import Head from "next/head";
+
+import styles from "@/styles/posts/create.module.css";
+
+export default function PostCreate() {
+  return (
+    <Layout>
+      <Head>
+        <title>Post Create</title>
+      </Head>
+      <div className={styles.form}>
+        <form action="/api/posts" method="post">
+          <div className={styles.form_title}>
+            <input type="text" name="title" placeholder="Title" />
+          </div>
+          <div className={styles.form_body}>
+            <textarea name="body" placeholder="Leave a post" />
+          </div>
+          <input type="submit" value="Submit new post" />
+        </form>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/posts/list.tsx
+++ b/src/pages/posts/list.tsx
@@ -1,0 +1,50 @@
+import Head from "next/head";
+import Link from "next/link";
+
+import Layout from "@/components/layout";
+import styles from "@/styles/posts/list.module.css";
+import Pager from "@/components/ui/pager";
+
+export default function PostList() {
+  const resp = {
+    total_count: 2,
+    posts: [
+      {
+        id: "f7c6436a-f346-4066-bee9-57ff9566ef51",
+        title: "This is a post title",
+        body: "This is a post body",
+        created_at: "2023-03-26T10:04:39.445113",
+        updated_at: "2023-03-26T10:04:39.445113"
+      },
+      {
+        id: "07c6436a-f346-4066-bee9-57ff9566ef51",
+        title: "Delete me",
+        body: "hogebar",
+        created_at: "2023-03-26T10:04:39.445113",
+        updated_at: "2023-03-26T10:04:39.445113"
+      }
+
+    ]
+  };
+
+  return (
+    <Layout>
+      <Head>
+        <title>Post List</title>
+      </Head>
+      <div className={styles.list_wrapper}>
+        <h1 className={styles.headline}>Post List</h1>
+        <div className={styles.list}>
+          {resp.posts.map((post) =>
+            <div key={post.id} className={styles.item}>
+              <div className={styles.item_title}>{post.title}</div>
+              <div className={styles.item_time}>Posted 2 days ago</div>
+              <Link href={`/posts/${post.id}`} className={styles.item_link}></Link>
+            </div>
+          )}
+        </div>
+        <Pager path="/posts/list" query={"?page=1"} totalCount={resp.total_count} perPage={1} />
+      </div>
+    </Layout>
+  );
+}

--- a/src/styles/posts/create.module.css
+++ b/src/styles/posts/create.module.css
@@ -1,0 +1,46 @@
+.form {
+  padding: 1em;
+}
+
+.form form {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.form input,
+.form textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #888;
+  border-radius: 0.25em;
+}
+
+.form_title input {
+  font-size: 1.2em;
+  padding: 0.5em 1em;
+}
+
+.form_body textarea {
+  font-size: 1em;
+  box-sizing: border-box;
+  width: 100%;
+  height: 10em;
+  padding: 0.5em;
+}
+
+.form input[type="submit"] {
+  cursor: pointer;
+  opacity: 0.9;
+  font-size: 1em;
+  padding: 0.5em 1em;
+  background-color: green;
+  color: #fff;
+}
+
+.form input[type="submit"]:hover {
+  opacity: 1;
+}

--- a/src/styles/posts/list.module.css
+++ b/src/styles/posts/list.module.css
@@ -1,0 +1,52 @@
+.headline {
+  font-size: 2em;
+  font-weight: bold;
+  text-align: center;
+  text-transform: uppercase;
+  word-spacing: 8px;
+  letter-spacing: 4px;
+}
+
+.list_wrapper {
+  padding: 1em;
+}
+
+.list {
+  border: 1px solid #ddd;
+  border-radius: 0.5em;
+}
+
+.item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  padding: 1em;
+  border-bottom: 1px solid #ddd;
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.item:hover {
+  background: #eee;
+}
+
+.item_title {
+  font-size: 1em;
+  color: black;
+}
+
+.item_time {
+  font-size: 0.8em;
+  color: #888;
+}
+
+.item_link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}

--- a/src/styles/posts/uid.module.css
+++ b/src/styles/posts/uid.module.css
@@ -1,0 +1,91 @@
+.title {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 1em;
+}
+
+.title h1,
+.title input {
+  font-size: 2em;
+  font-weight: bold;
+  margin: 0.67em 0;
+}
+
+.title h1,
+.title form {
+  width: 100%;
+  flex: 3;
+}
+
+.title input {
+  width: 100%;
+  font-size: 1.5em;
+  padding: 0.25em;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.article_wrap {
+  padding: 1em;
+}
+
+.article {
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.article_control {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9em;
+  padding: 0.5em 1em;
+  border-bottom: 1px solid #ccc;
+  background-color: #eee;
+}
+
+.article_body,
+.article form {
+  font-size: 1em;
+  padding: 1em;
+}
+
+.article_body,
+.article form textarea {
+  line-height: 1.5;
+  word-spacing: 2px;
+  letter-spacing: 1px;
+}
+
+.article form {
+  width: 100%;
+  padding: 1em;
+  box-sizing: border-box;
+}
+
+.article form textarea {
+  width: 100%;
+  height: 20em;
+  margin: 0;
+  padding: 0.5em;
+  border: none;
+  border-radius: 5px;
+  box-sizing: border-box;
+}
+
+.editbtn {
+  cursor: pointer;
+  border: none;
+  padding: none;
+  margin: none;
+  margin-left: 1em;
+  background-color: transparent;
+  color: black;
+}
+
+.editbtn svg {
+  margin-right: 0.5em;
+}


### PR DESCRIPTION
# 概要

以下のURLに対応したエンドポイントとスタイルを作成しました。

- `/posts/list`
- `/posts/[uid]`
- `/posts/create`

Issue #26

## 変更内容

- /posts/list

<img width="1440" alt="スクリーンショット 2023-04-14 2 03 55" src="https://user-images.githubusercontent.com/73953416/231832861-49887a89-304e-41cc-8e11-b9dcbd8c03b2.png">

- /posts/[uid]

<img width="1440" alt="スクリーンショット 2023-04-14 2 05 32" src="https://user-images.githubusercontent.com/73953416/231833235-7073e104-4ee0-429d-8b55-572e54a94200.png">

- /posts/create

<img width="1440" alt="スクリーンショット 2023-04-14 2 05 41" src="https://user-images.githubusercontent.com/73953416/231833278-339e8e1d-2c73-4a38-8075-4a1b9353c161.png">

## 動作要件

ブラウザ上で以下のURLにアクセスすることでページを確認できます。

- http://localhost:3000/posts/list
- http://localhost:3000/posts/uid
- http://localhost:3000/posts/create