### PR TITLE
fix: :bug: article link css

### DIFF
--- a/src/app/articles/[slug]/page.module.css
+++ b/src/app/articles/[slug]/page.module.css
@@ -140,6 +140,7 @@
 .content_html a {
   color: var(--color-text-link);
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .content_html a:hover {


### PR DESCRIPTION
**主な変更内容**

記事のリンクが長すぎると枠内からはみ出る問題を修正しました

**イシュー番号**

Issue: #78

**チェックリスト**

- [x] 記事内の長いリンクを確認
