### PR TITLE
fix: :bug: article image path

### DIFF
--- a/src/app/articles/lib.ts
+++ b/src/app/articles/lib.ts
@@ -81,7 +81,7 @@ function replaceRelativeUrlToAbsoluteUrl(path: string, content: string): string 
 
   content.match(relativeImageRegex)?.forEach((relativeImage) => {
     if (imageUrlRegex.test(relativeImage)) {
-      const url = imageUrlRegex.exec(relativeImage)![1].replace(/^\.\//, "");
+      const url = imageUrlRegex.exec(relativeImage)![1]
       content = content.replace(url, `${absoluteUrl.href}/${url}`)
     }
   })


### PR DESCRIPTION
**主な変更内容**

記事の画像リンクをサイトように置き換える処理に不具合があったので修正しました。

詳細はイシューをご覧ください

**イシュー番号**

Issue: #81

**チェックリスト**

- [x] `/articles/tech-fontawesome-nextjs-big-icon`にアクセスし、画像がきちんと表示されているか
